### PR TITLE
OE-142 remove auto save when change input and add save change button …

### DIFF
--- a/app/Http/Controllers/NumberTrackingController.php
+++ b/app/Http/Controllers/NumberTrackingController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Livewire\NumberTracker\DailyEntry;
 use App\Models\DailyNumber;
 use Illuminate\Http\Request;
 
@@ -26,14 +27,17 @@ class NumberTrackingController extends Controller
         // $this->authorize('update', [DailyNumber::class, $data['officeSelected']]);
 
         if (!empty($data['numbers'])) {
-            $date = ($data['date']) ? date('Y-m-d', strtotime($data['date'])) : date('Y-m-d', time()); 
+            $date = ($data['date']) ? date('Y-m-d', strtotime($data['date'])) : date('Y-m-d', time());
 
             foreach ($data['numbers'] as $userId => $numbers) {
                 $filteredNumbers = array_filter($numbers, function ($element) {
-                    return ($element >= 0 && !is_null($element));
+                    return ($element >= 0);
                 });
 
-                if (!empty($filteredNumbers)) {
+                $isEmpty = empty(array_filter($filteredNumbers, function($item) {return $item !== null;}));
+
+                if (!$isEmpty) {
+
                     DailyNumber::updateOrCreate(
                         [
                             'user_id' => $userId,
@@ -41,6 +45,10 @@ class NumberTrackingController extends Controller
                         ],
                         $filteredNumbers
                     );
+                } else {
+                    $dailyNumber = DailyNumber::whereDate('date', $date)->whereUserId($userId)->first();
+                    if(!empty($dailyNumber))
+                        DailyNumber::destroy($dailyNumber->id);
                 }
             }
             alert()

--- a/app/Http/Livewire/NumberTracker/DailyEntry.php
+++ b/app/Http/Livewire/NumberTracker/DailyEntry.php
@@ -113,6 +113,7 @@ class DailyEntry extends Component
         empty($office);
     }
 
+    //this function will be removed when OE-149 is validated
     public function save($value, $userId, $inputType)
     {
         $filteredNumbers = [

--- a/resources/views/livewire/number-tracker/daily-entry.blade.php
+++ b/resources/views/livewire/number-tracker/daily-entry.blade.php
@@ -105,12 +105,11 @@
                                 @endforeach
                                 <input name="officeSelected" id="officeSelected" value="{{ $officeSelected }}" class="hidden"/>
 
-                                {{-- after validate the change Number Number Tracker -> Auto-save this can be deleted --}}
-                                {{-- <div class="mt-6">
+                                <div class="mt-6">
                                     <x-button type="submit" color="green" class="inline-flex w-full">
                                         Save Changes
                                     </x-button>
-                                </div> --}}
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -228,7 +227,7 @@
                         color="#9fa6b2"
                         class="self-center hidden w-20 mt-3"
                         wire:loading.class.remove="hidden"
-                        wire:target="setOffice, setDate">
+                        wire:target="setOffice, setDate, store">
                     </x-svg.spinner>
 
                     <div class="w-full mt-3">
@@ -236,7 +235,7 @@
                             <div class="flex flex-col">
                                 <div class="overflow-x-auto">
                                     <div class="inline-block min-w-full overflow-hidden align-middle">
-                                        <x-table wire:loading.remove wire:target="setOffice, setDate">
+                                        <x-table wire:loading.remove>
                                             <x-slot name="header">
                                                 <x-table.th-tr>
                                                     <x-table.th by="region_member">
@@ -271,7 +270,8 @@
                                                         <x-table.td>
                                                             <input
                                                                 type="number"
-                                                                x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'doors')"
+                                                                {{-- when OE-142 is validated this line will be removed --}}
+                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'doors')" --}}
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][doors]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
@@ -282,7 +282,8 @@
                                                                 type="number"
                                                                 min="0"
                                                                 max="24"
-                                                                x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'hours')"
+                                                                {{-- when OE-142 is validated this line will be removed --}}
+                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'hours')" --}}
                                                                 oninvalid="this.setCustomValidity('Value must be less than or equal 24')"
                                                                 onchange="this.setCustomValidity('')"
                                                                 step="any"
@@ -294,7 +295,8 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'sets')"
+                                                                {{-- when OE-142 is validated this line will be removed --}}
+                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'sets')" --}}
                                                                 name="numbers[{{ $user->id }}][sets]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->sets }}"/>
@@ -303,7 +305,8 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'sits')"
+                                                                {{-- when OE-142 is validated this line will be removed --}}
+                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'sits')" --}}
                                                                 name="numbers[{{ $user->id }}][sits]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->sits }}"/>
@@ -312,7 +315,8 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'set_closes')"
+                                                                {{-- when OE-142 is validated this line will be removed --}}
+                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'set_closes')" --}}
                                                                 name="numbers[{{ $user->id }}][set_closes]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->set_closes }}"/>
@@ -321,7 +325,8 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'closes')"
+                                                                {{-- when OE-142 is validated this line will be removed --}}
+                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'closes')" --}}
                                                                 name="numbers[{{ $user->id }}][closes]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->closes }}"/>


### PR DESCRIPTION
…again

## Goal

Remove autosave

## Changeset

-when the logged user insert data on inputs, will be necessary to click on save changes

## Tests

- [ ] Go to one-energy
- [ ] Make login with the Department manager account
- [ ] Go to number tracker
- [ ] Click on update numbers
- [ ] Insert numbers and click on save changes 

## Discussion


## Review


For the submitter, initial self-review:

- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency between the changeset and the goal stated above
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Complexity - is the proposed change introducing any unjustified complexity? 
- [ ] Thoroughness of added tests and any missing edge cases
