### PR TITLE
OE-159 Error when add a region on filter

### DIFF
--- a/app/Http/Livewire/NumberTracker/NumberTrackerDetail.php
+++ b/app/Http/Livewire/NumberTracker/NumberTrackerDetail.php
@@ -94,12 +94,7 @@ class NumberTrackerDetail extends Component
             ->select([DB::raw("users.first_name, users.last_name, daily_numbers.id, daily_numbers.user_id, SUM(doors) as doors,
                     SUM(hours) as hours,  SUM(sets) as sets,  SUM(sits) as sits,  SUM(set_closes) as set_closes, SUM(closes) as closes")]);
 
-        $queryLast = DailyNumber::query()
-            ->leftJoin('users', function ($join) {
-                $join->on('users.id', '=', 'daily_numbers.user_id');
-            })
-            ->select([DB::raw("users.first_name, users.last_name, daily_numbers.id, daily_numbers.user_id, SUM(doors) as doors,
-                    SUM(hours) as hours,  SUM(sets) as sets,  SUM(sits) as sits,  SUM(set_closes) as set_closes, SUM(closes) as closes")]);
+        $queryLast = clone $query;
 
         if ($this->period == 'd') {
             $query->whereDate('date', $this->dateSelected);


### PR DESCRIPTION
## Goal

Fix error when adding a region on filter in number tracker detail page

## Changeset


## Tests

- [ ] Go to one energy project and open number tracker pager
- [ ] add regions to filter and verify if its all right

## Discussion


## Review


For the submitter, initial self-review:

- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency between the changeset and the goal stated above
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Complexity - is the proposed change introducing any unjustified complexity? 
- [ ] Thoroughness of added tests and any missing edge cases
