### PR TITLE
Feature/oe 164 add set sits throughout system

### DIFF
--- a/app/Http/Livewire/NumberTracker/DailyEntry.php
+++ b/app/Http/Livewire/NumberTracker/DailyEntry.php
@@ -5,6 +5,7 @@ namespace App\Http\Livewire\NumberTracker;
 use App\Models\DailyNumber;
 use App\Models\Office;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
 
 class DailyEntry extends Component
@@ -47,21 +48,10 @@ class DailyEntry extends Component
 
         return $usersQuery
             ->whereOfficeId($this->officeSelected)
-            ->leftJoin('daily_numbers', function($join) use ($dateSelected) {
-                $join->on('daily_numbers.user_id', '=', 'users.id')
-                    ->where('daily_numbers.date', '=', $dateSelected);
-            })
-            ->orderBy($this->sortBy())
-            ->select(
-                'users.*',
-                'daily_numbers.doors',
-                'daily_numbers.hours',
-                'daily_numbers.sets',
-                'daily_numbers.set_sits',
-                'daily_numbers.sits',
-                'daily_numbers.set_closes',
-                'daily_numbers.closes'
-            )
+            ->with(['dailyNumbers' => function($query) use ($dateSelected) {
+                $query->whereDate('date', $dateSelected);
+            }])
+            ->orderBy('first_name')
             ->get();
     }
 

--- a/app/Http/Livewire/NumberTracker/DailyEntry.php
+++ b/app/Http/Livewire/NumberTracker/DailyEntry.php
@@ -57,6 +57,7 @@ class DailyEntry extends Component
                 'daily_numbers.doors',
                 'daily_numbers.hours',
                 'daily_numbers.sets',
+                'daily_numbers.set_sits',
                 'daily_numbers.sits',
                 'daily_numbers.set_closes',
                 'daily_numbers.closes'

--- a/app/Http/Livewire/NumberTracker/NumberTrackerDetail.php
+++ b/app/Http/Livewire/NumberTracker/NumberTrackerDetail.php
@@ -92,7 +92,7 @@ class NumberTrackerDetail extends Component
             })
             ->join('offices', 'users.office_id', '=', 'offices.id')
             ->select([DB::raw("users.first_name, users.last_name, daily_numbers.id, daily_numbers.user_id, SUM(doors) as doors,
-                    SUM(hours) as hours,  SUM(sets) as sets,  SUM(sits) as sits,  SUM(set_closes) as set_closes, SUM(closes) as closes")]);
+                    SUM(hours) as hours,  SUM(sets) as sets, SUM(set_sits) as set_sits,  SUM(sits) as sits,  SUM(set_closes) as set_closes, SUM(closes) as closes")]);
 
         $queryLast = clone $query;
 

--- a/app/Models/DailyNumber.php
+++ b/app/Models/DailyNumber.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class DailyNumber extends Model
 {
-    protected $fillable = ['user_id', 'date', 'doors', 'hours', 'sets', 'sits', 'set_closes', 'closes'];
+    protected $fillable = ['user_id', 'date', 'doors', 'hours', 'sets', 'set_sits', 'sits', 'set_closes', 'closes'];
 
     public function user()
     {

--- a/database/migrations/2021_03_04_200835_add_set_sits_column_to_daily_numbers_table.php
+++ b/database/migrations/2021_03_04_200835_add_set_sits_column_to_daily_numbers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSetSitsColumnToDailyNumbersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('daily_numbers', function (Blueprint $table) {
+            $table->integer('set_sits')->after('sets')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('daily_numbers', function (Blueprint $table) {
+            $table->dropColumn('set_sits');
+        });
+    }
+}

--- a/resources/views/livewire/number-tracker/daily-entry.blade.php
+++ b/resources/views/livewire/number-tracker/daily-entry.blade.php
@@ -250,6 +250,9 @@
                                                     <x-table.th by="sets">
                                                         @lang('Sets')
                                                     </x-table.th>
+                                                    <x-table.th by="set_sits">
+                                                        @lang('Set Sits')
+                                                    </x-table.th>
                                                     <x-table.th by="sits">
                                                         @lang('Sits')
                                                     </x-table.th>
@@ -270,8 +273,6 @@
                                                         <x-table.td>
                                                             <input
                                                                 type="number"
-                                                                {{-- when OE-142 is validated this line will be removed --}}
-                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'doors')" --}}
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][doors]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
@@ -282,8 +283,6 @@
                                                                 type="number"
                                                                 min="0"
                                                                 max="24"
-                                                                {{-- when OE-142 is validated this line will be removed --}}
-                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'hours')" --}}
                                                                 oninvalid="this.setCustomValidity('Value must be less than or equal 24')"
                                                                 onchange="this.setCustomValidity('')"
                                                                 step="any"
@@ -305,8 +304,14 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                {{-- when OE-142 is validated this line will be removed --}}
-                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'sits')" --}}
+                                                                name="numbers[{{ $user->id }}][set_sits]"
+                                                                class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
+                                                                value="{{ $user->set_sits }}"/>
+                                                        </x-table.td>
+                                                        <x-table.td>
+                                                            <input
+                                                                type="number"
+                                                                min="0"
                                                                 name="numbers[{{ $user->id }}][sits]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->sits }}"/>
@@ -315,8 +320,6 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                {{-- when OE-142 is validated this line will be removed --}}
-                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'set_closes')" --}}
                                                                 name="numbers[{{ $user->id }}][set_closes]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->set_closes }}"/>
@@ -325,8 +328,6 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                {{-- when OE-142 is validated this line will be removed --}}
-                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'closes')" --}}
                                                                 name="numbers[{{ $user->id }}][closes]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->closes }}"/>

--- a/resources/views/livewire/number-tracker/daily-entry.blade.php
+++ b/resources/views/livewire/number-tracker/daily-entry.blade.php
@@ -117,8 +117,8 @@
 
                 <div class="flex flex-wrap justify-center px-4 py-5 h-1/2 sm:p-6 md:w-2/3 lg:3/4">
                     <div class="w-full mt-11 xl:px-0 lg:px-24 md:px-0">
-                        <div class="grid grid-cols-3 row-gap-2 col-gap-1 xl:grid-cols-6 md:col-gap-4">
-                            <div class="col-span-1 p-3 border-2 border-gray-200 rounded-lg">
+                        <div class="grid grid-cols-6 row-gap-2 col-gap-1 xl:grid-cols-7 md:col-gap-4">
+                            <div class="col-span-2 xl:col-span-1 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold uppercase">Doors</div>
                                 <div class="text-xl font-bold">{{$users->sum('doors')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('doors') >= $usersLastDayEntries->sum('doors')) text-green-base @else text-red-600 @endif">
@@ -135,7 +135,7 @@
                                     @endif
                                 </div>
                             </div>
-                            <div class="col-span-1 p-3 border-2 border-gray-200 rounded-lg">
+                            <div class="col-span-2 xl:col-span-1 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Hours</div>
                                 <div class="text-xl font-bold text-gray-900">{{$users->sum('hours')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('hours') >= $usersLastDayEntries->sum('hours')) text-green-base @else text-red-600 @endif">
@@ -152,7 +152,7 @@
                                     @endif
                                 </div>
                             </div>
-                            <div class="col-span-1 p-3 border-2 border-gray-200 rounded-lg">
+                            <div class="col-span-2 xl:col-span-1 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Sets</div>
                                 <div class="text-xl font-bold text-gray-900">{{$users->sum('sets')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('sets') >= $usersLastDayEntries->sum('sets')) text-green-base @else text-red-600 @endif">
@@ -169,24 +169,48 @@
                                     @endif
                                 </div>
                             </div>
-                            <div class="col-span-1 p-3 border-2 border-gray-200 rounded-lg">
+                            <div class="col-span-3 xl:col-span-2 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Sits</div>
-                                <div class="text-xl font-bold text-gray-900">{{$users->sum('sits')}}</div>
-                                <div class="flex font-semibold text-xs @if($users->sum('sits') >= $usersLastDayEntries->sum('sits')) text-green-base @else text-red-600 @endif">
-                                    @if($users->sum('sits') >= $usersLastDayEntries->sum('sits'))
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
-                                        <span>
-                                            +{{$users->sum('sits') - $usersLastDayEntries->sum('sits')}}
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">Set</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('set_sits')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($users->sum('set_sits') - $usersLastDayEntries->sum('set_sits') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($users->sum('set_sits') - $usersLastDayEntries->sum('set_sits') >= 0)
+                                                    text-green-base
+                                                @else
+                                                    text-red-600
+                                                @endif">
+                                            {{$users->sum('set_sits') - $usersLastDayEntries->sum('set_sits')}}
                                         </span>
-                                    @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-up>
-                                        <span>
+                                    </div>
+                                </div>
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">SG</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('sits')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($users->sum('sits') - $usersLastDayEntries->sum('sits') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($users->sum('sits') - $usersLastDayEntries->sum('sits') >= 0)
+                                                    text-green-base
+                                                @else
+                                                    text-red-600
+                                                @endif">
                                             {{$users->sum('sits') - $usersLastDayEntries->sum('sits')}}
                                         </span>
-                                    @endif
+                                    </div>
                                 </div>
                             </div>
-                            <div class="col-span-1 p-3 border-2 border-gray-200 rounded-lg">
+                            {{-- <div class="col-span-1 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Set closes</div>
                                 <div class="text-xl font-bold text-gray-900">{{$users->sum('set_closes')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('set_closes') >= $usersLastDayEntries->sum('set_closes')) text-green-base @else text-red-600 @endif">
@@ -202,22 +226,46 @@
                                         </span>
                                     @endif
                                 </div>
-                            </div>
-                            <div class="col-span-1 p-3 border-2 border-gray-200 rounded-lg">
+                            </div> --}}
+                            <div class="col-span-3 xl:col-span-2 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Closes</div>
-                                <div class="text-xl font-bold text-gray-900">{{$users->sum('closes')}}</div>
-                                <div class="flex font-semibold text-xs @if($users->sum('closes') >= $usersLastDayEntries->sum('closes')) text-green-base @else text-red-600 @endif">
-                                    @if($users->sum('closes') >= $usersLastDayEntries->sum('closes'))
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
-                                        <span>
-                                            +{{$users->sum('closes') - $usersLastDayEntries->sum('closes')}}
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">Set</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('set_closes')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($users->sum('set_closes') - $usersLastDayEntries->sum('set_closes') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($users->sum('set_closes') - $usersLastDayEntries->sum('set_closes') >= 0)
+                                                    text-green-base
+                                                @else
+                                                    text-red-600
+                                                @endif">
+                                            {{$users->sum('set_closes') - $usersLastDayEntries->sum('set_closes')}}
                                         </span>
-                                    @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-up>
-                                        <span>
+                                    </div>
+                                </div>
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">SG</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('sits')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($users->sum('closes') - $usersLastDayEntries->sum('closes') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($users->sum('closes') - $usersLastDayEntries->sum('closes') >= 0)
+                                                    text-green-base
+                                                @else
+                                                    text-red-600
+                                                @endif">
                                             {{$users->sum('closes') - $usersLastDayEntries->sum('closes')}}
                                         </span>
-                                    @endif
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -294,8 +342,6 @@
                                                             <input
                                                                 type="number"
                                                                 min="0"
-                                                                {{-- when OE-142 is validated this line will be removed --}}
-                                                                {{-- x-on:focusout="$wire.save($event.target.value, {{$user->id}}, 'sets')" --}}
                                                                 name="numbers[{{ $user->id }}][sets]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
                                                                 value="{{ $user->sets }}"/>

--- a/resources/views/livewire/number-tracker/daily-entry.blade.php
+++ b/resources/views/livewire/number-tracker/daily-entry.blade.php
@@ -123,12 +123,12 @@
                                 <div class="text-xl font-bold">{{$users->sum('doors')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('doors') >= $usersLastDayEntries->sum('doors')) text-green-base @else text-red-600 @endif">
                                     @if($users->sum('doors') >= $usersLastDayEntries->sum('doors'))
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                         <span>
                                             +{{$users->sum('doors') - $usersLastDayEntries->sum('doors')}}
                                         </span>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-up>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                         <span>
                                             {{$users->sum('doors') - $usersLastDayEntries->sum('doors')}}
                                         </span>
@@ -140,12 +140,12 @@
                                 <div class="text-xl font-bold text-gray-900">{{$users->sum('hours')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('hours') >= $usersLastDayEntries->sum('hours')) text-green-base @else text-red-600 @endif">
                                     @if($users->sum('hours') >= $usersLastDayEntries->sum('hours'))
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                         <span>
                                             +{{$users->sum('hours') - $usersLastDayEntries->sum('hours')}}
                                         </span>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-up>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                         <span>
                                             {{$users->sum('hours') - $usersLastDayEntries->sum('hours')}}
                                         </span>
@@ -157,12 +157,12 @@
                                 <div class="text-xl font-bold text-gray-900">{{$users->sum('sets')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('sets') >= $usersLastDayEntries->sum('sets')) text-green-base @else text-red-600 @endif">
                                     @if($users->sum('sets') >= $usersLastDayEntries->sum('sets'))
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                         <span>
                                             +{{$users->sum('sets') - $usersLastDayEntries->sum('sets')}}
                                         </span>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-up>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                         <span>
                                             {{$users->sum('sets') - $usersLastDayEntries->sum('sets')}}
                                         </span>
@@ -176,9 +176,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('set_sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($users->sum('set_sits') - $usersLastDayEntries->sum('set_sits') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($users->sum('set_sits') - $usersLastDayEntries->sum('set_sits') >= 0)
@@ -195,9 +195,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($users->sum('sits') - $usersLastDayEntries->sum('sits') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($users->sum('sits') - $usersLastDayEntries->sum('sits') >= 0)
@@ -215,12 +215,12 @@
                                 <div class="text-xl font-bold text-gray-900">{{$users->sum('set_closes')}}</div>
                                 <div class="flex font-semibold text-xs @if($users->sum('set_closes') >= $usersLastDayEntries->sum('set_closes')) text-green-base @else text-red-600 @endif">
                                     @if($users->sum('set_closes') >= $usersLastDayEntries->sum('set_closes'))
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                         <span>
                                             +{{$users->sum('set_closes') - $usersLastDayEntries->sum('set_closes')}}
                                         </span>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-up>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                         <span>
                                             {{$users->sum('set_closes') - $usersLastDayEntries->sum('set_closes')}}
                                         </span>
@@ -234,9 +234,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('set_closes')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($users->sum('set_closes') - $usersLastDayEntries->sum('set_closes') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($users->sum('set_closes') - $usersLastDayEntries->sum('set_closes') >= 0)
@@ -253,9 +253,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($users->sum('closes') - $usersLastDayEntries->sum('closes') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($users->sum('closes') - $usersLastDayEntries->sum('closes') >= 0)

--- a/resources/views/livewire/number-tracker/daily-entry.blade.php
+++ b/resources/views/livewire/number-tracker/daily-entry.blade.php
@@ -250,7 +250,7 @@
                                 </div>
                                 <div class="grid grid-cols-4 gap-1">
                                     <div class="text-sm self-center col-span-1">SG</div>
-                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('sits')}}</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('closes')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($users->sum('closes') - $usersLastDayEntries->sum('closes') >= 0)
                                             <x-svg.arrow-up class="text-green-base"/>

--- a/resources/views/livewire/number-tracker/daily-entry.blade.php
+++ b/resources/views/livewire/number-tracker/daily-entry.blade.php
@@ -120,51 +120,51 @@
                         <div class="grid grid-cols-6 row-gap-2 col-gap-1 xl:grid-cols-7 md:col-gap-4">
                             <div class="col-span-2 xl:col-span-1 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold uppercase">Doors</div>
-                                <div class="text-xl font-bold">{{$users->sum('doors')}}</div>
-                                <div class="flex font-semibold text-xs @if($users->sum('doors') >= $usersLastDayEntries->sum('doors')) text-green-base @else text-red-600 @endif">
-                                    @if($users->sum('doors') >= $usersLastDayEntries->sum('doors'))
+                                <div class="text-xl font-bold">{{$users->sum('dailyNumbers.0.doors')}}</div>
+                                <div class="flex font-semibold text-xs @if($users->sum('dailyNumbers.0.doors') >= $usersLastDayEntries->sum('dailyNumbers.0.doors')) text-green-base @else text-red-600 @endif">
+                                    @if($users->sum('dailyNumbers.0.doors') >= $usersLastDayEntries->sum('dailyNumbers.0.doors'))
                                         <x-svg.arrow-up class="text-green-base"/>
                                         <span>
-                                            +{{$users->sum('doors') - $usersLastDayEntries->sum('doors')}}
+                                            +{{$users->sum('dailyNumbers.0.doors') - $usersLastDayEntries->sum('dailyNumbers.0.doors')}}
                                         </span>
                                     @else
                                         <x-svg.arrow-down class="text-red-600"/>
                                         <span>
-                                            {{$users->sum('doors') - $usersLastDayEntries->sum('doors')}}
+                                            {{$users->sum('dailyNumbers.0.doors') - $usersLastDayEntries->sum('dailyNumbers.0.doors')}}
                                         </span>
                                     @endif
                                 </div>
                             </div>
                             <div class="col-span-2 xl:col-span-1 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Hours</div>
-                                <div class="text-xl font-bold text-gray-900">{{$users->sum('hours')}}</div>
-                                <div class="flex font-semibold text-xs @if($users->sum('hours') >= $usersLastDayEntries->sum('hours')) text-green-base @else text-red-600 @endif">
-                                    @if($users->sum('hours') >= $usersLastDayEntries->sum('hours'))
+                                <div class="text-xl font-bold text-gray-900">{{$users->sum('dailyNumber.0.hours')}}</div>
+                                <div class="flex font-semibold text-xs @if($users->sum('dailyNumber.0.hours') >= $usersLastDayEntries->sum('dailyNumber.0.hours')) text-green-base @else text-red-600 @endif">
+                                    @if($users->sum('dailyNumber.0.hours') >= $usersLastDayEntries->sum('dailyNumber.0.hours'))
                                         <x-svg.arrow-up class="text-green-base"/>
                                         <span>
-                                            +{{$users->sum('hours') - $usersLastDayEntries->sum('hours')}}
+                                            +{{$users->sum('dailyNumber.0.hours') - $usersLastDayEntries->sum('dailyNumber.0.hours')}}
                                         </span>
                                     @else
                                         <x-svg.arrow-down class="text-red-600"/>
                                         <span>
-                                            {{$users->sum('hours') - $usersLastDayEntries->sum('hours')}}
+                                            {{$users->sum('dailyNumber.0.hours') - $usersLastDayEntries->sum('dailyNumber.0.hours')}}
                                         </span>
                                     @endif
                                 </div>
                             </div>
                             <div class="col-span-2 xl:col-span-1 p-3 border-2 border-gray-200 rounded-lg">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Sets</div>
-                                <div class="text-xl font-bold text-gray-900">{{$users->sum('sets')}}</div>
-                                <div class="flex font-semibold text-xs @if($users->sum('sets') >= $usersLastDayEntries->sum('sets')) text-green-base @else text-red-600 @endif">
-                                    @if($users->sum('sets') >= $usersLastDayEntries->sum('sets'))
+                                <div class="text-xl font-bold text-gray-900">{{$users->sum('dailyNumbers.0.sets')}}</div>
+                                <div class="flex font-semibold text-xs @if($users->sum('dailyNumbers.0.sets') >= $usersLastDayEntries->sum('dailyNumbers.0.sets')) text-green-base @else text-red-600 @endif">
+                                    @if($users->sum('dailyNumbers.0.sets') >= $usersLastDayEntries->sum('dailyNumbers.0.sets'))
                                         <x-svg.arrow-up class="text-green-base"/>
                                         <span>
-                                            +{{$users->sum('sets') - $usersLastDayEntries->sum('sets')}}
+                                            +{{$users->sum('dailyNumbers.0.sets') - $usersLastDayEntries->sum('dailyNumbers.0.sets')}}
                                         </span>
                                     @else
                                         <x-svg.arrow-down class="text-red-600"/>
                                         <span>
-                                            {{$users->sum('sets') - $usersLastDayEntries->sum('sets')}}
+                                            {{$users->sum('dailyNumbers.0.sets') - $usersLastDayEntries->sum('dailyNumbers.0.sets')}}
                                         </span>
                                     @endif
                                 </div>
@@ -173,39 +173,39 @@
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Sits</div>
                                 <div class="grid grid-cols-4 gap-1">
                                     <div class="text-sm self-center col-span-1">Set</div>
-                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('set_sits')}}</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('dailyNumbers.0.set_sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
-                                        @if($users->sum('set_sits') - $usersLastDayEntries->sum('set_sits') >= 0)
+                                        @if($users->sum('dailyNumbers.0.set_sits') - $usersLastDayEntries->sum('dailyNumbers.0.set_sits') >= 0)
                                             <x-svg.arrow-up class="text-green-base"/>
                                         @else
                                             <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
-                                                @if($users->sum('set_sits') - $usersLastDayEntries->sum('set_sits') >= 0)
+                                                @if($users->sum('dailyNumbers.0.set_sits') - $usersLastDayEntries->sum('dailyNumbers.0.set_sits') >= 0)
                                                     text-green-base
                                                 @else
                                                     text-red-600
                                                 @endif">
-                                            {{$users->sum('set_sits') - $usersLastDayEntries->sum('set_sits')}}
+                                            {{$users->sum('dailyNumbers.0.set_sits') - $usersLastDayEntries->sum('dailyNumbers.0.set_sits')}}
                                         </span>
                                     </div>
                                 </div>
                                 <div class="grid grid-cols-4 gap-1">
                                     <div class="text-sm self-center col-span-1">SG</div>
-                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('sits')}}</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('dailyNumbers.0.sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
-                                        @if($users->sum('sits') - $usersLastDayEntries->sum('sits') >= 0)
+                                        @if($users->sum('dailyNumbers.0.sits') - $usersLastDayEntries->sum('dailyNumbers.0.sits') >= 0)
                                             <x-svg.arrow-up class="text-green-base"/>
                                         @else
                                             <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
-                                                @if($users->sum('sits') - $usersLastDayEntries->sum('sits') >= 0)
+                                                @if($users->sum('dailyNumbers.0.sits') - $usersLastDayEntries->sum('dailyNumbers.0.sits') >= 0)
                                                     text-green-base
                                                 @else
                                                     text-red-600
                                                 @endif">
-                                            {{$users->sum('sits') - $usersLastDayEntries->sum('sits')}}
+                                            {{$users->sum('dailyNumbers.0.sits') - $usersLastDayEntries->sum('dailyNumbers.0.sits')}}
                                         </span>
                                     </div>
                                 </div>
@@ -231,39 +231,39 @@
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Closes</div>
                                 <div class="grid grid-cols-4 gap-1">
                                     <div class="text-sm self-center col-span-1">Set</div>
-                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('set_closes')}}</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('dailyNumbers.0.set_closes')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
-                                        @if($users->sum('set_closes') - $usersLastDayEntries->sum('set_closes') >= 0)
+                                        @if($users->sum('dailyNumbers.0.set_closes') - $usersLastDayEntries->sum('dailyNumbers.0.set_closes') >= 0)
                                             <x-svg.arrow-up class="text-green-base"/>
                                         @else
                                             <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
-                                                @if($users->sum('set_closes') - $usersLastDayEntries->sum('set_closes') >= 0)
+                                                @if($users->sum('dailyNumbers.0.set_closes') - $usersLastDayEntries->sum('dailyNumbers.0.set_closes') >= 0)
                                                     text-green-base
                                                 @else
                                                     text-red-600
                                                 @endif">
-                                            {{$users->sum('set_closes') - $usersLastDayEntries->sum('set_closes')}}
+                                            {{$users->sum('dailyNumbers.0.set_closes') - $usersLastDayEntries->sum('dailyNumbers.0.set_closes')}}
                                         </span>
                                     </div>
                                 </div>
                                 <div class="grid grid-cols-4 gap-1">
                                     <div class="text-sm self-center col-span-1">SG</div>
-                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('closes')}}</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$users->sum('dailyNumbers.0.closes')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
-                                        @if($users->sum('closes') - $usersLastDayEntries->sum('closes') >= 0)
+                                        @if($users->sum('dailyNumbers.0.closes') - $usersLastDayEntries->sum('dailyNumbers.0.closes') >= 0)
                                             <x-svg.arrow-up class="text-green-base"/>
                                         @else
                                             <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
-                                                @if($users->sum('closes') - $usersLastDayEntries->sum('closes') >= 0)
+                                                @if($users->sum('dailyNumbers.0.closes') - $usersLastDayEntries->sum('dailyNumbers.0.closes') >= 0)
                                                     text-green-base
                                                 @else
                                                     text-red-600
                                                 @endif">
-                                            {{$users->sum('closes') - $usersLastDayEntries->sum('closes')}}
+                                            {{$users->sum('dailyNumbers.0.closes') - $usersLastDayEntries->sum('dailyNumbers.0.closes')}}
                                         </span>
                                     </div>
                                 </div>
@@ -324,7 +324,7 @@
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][doors]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
-                                                                value="{{ $user->doors }}"/>
+                                                                value="{{ $user->dailyNumbers->sum('doors') }}"/>
                                                         </x-table.td>
                                                         <x-table.td>
                                                             <input
@@ -336,7 +336,7 @@
                                                                 step="any"
                                                                 name="numbers[{{ $user->id }}][hours]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
-                                                                value="{{ $user->hours }}"/>
+                                                                value="{{ $user->dailyNumbers->sum('hours') }}"/>
                                                         </x-table.td>
                                                         <x-table.td>
                                                             <input
@@ -344,7 +344,7 @@
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][sets]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
-                                                                value="{{ $user->sets }}"/>
+                                                                value="{{ $user->dailyNumbers->sum('sets') }}"/>
                                                         </x-table.td>
                                                         <x-table.td>
                                                             <input
@@ -352,7 +352,7 @@
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][set_sits]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
-                                                                value="{{ $user->set_sits }}"/>
+                                                                value="{{ $user->dailyNumbers->sum('set_sits') }}"/>
                                                         </x-table.td>
                                                         <x-table.td>
                                                             <input
@@ -360,7 +360,7 @@
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][sits]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
-                                                                value="{{ $user->sits }}"/>
+                                                                value="{{ $user->dailyNumbers->sum('sits') }}"/>
                                                         </x-table.td>
                                                         <x-table.td>
                                                             <input
@@ -368,7 +368,7 @@
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][set_closes]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
-                                                                value="{{ $user->set_closes }}"/>
+                                                                value="{{ $user->dailyNumbers->sum('set_closes') }}"/>
                                                         </x-table.td>
                                                         <x-table.td>
                                                             <input
@@ -376,7 +376,7 @@
                                                                 min="0"
                                                                 name="numbers[{{ $user->id }}][closes]"
                                                                 class="block transition duration-150 ease-in-out form-input w-14 sm:text-sm sm:leading-5"
-                                                                value="{{ $user->closes }}"/>
+                                                                value="{{ $user->dailyNumbers->sum('closes') }}"/>
                                                         </x-table.td>
                                                     </x-table.tr>
                                                 @endforeach

--- a/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
+++ b/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
@@ -308,8 +308,8 @@
                     </div>
 
                     <div class="flex justify-between mt-3">
-                        <div class="grid w-full grid-cols-3 row-gap-2 col-gap-1 xl:grid-cols-6 md:col-gap-4">
-                            <div class="col-span-1 border-2
+                        <div class="grid w-full grid-cols-6 row-gap-2 col-gap-1 xl:grid-cols-7 md:col-gap-4">
+                            <div class="col-span-2 xl:col-span-1 border-2
                                 @if($filterBy == 'doors')
                                     border-green-base bg-green-light
                                 @else
@@ -335,7 +335,7 @@
                                     </span>
                                 </div>
                             </div>
-                            <div class="col-span-1 border-2 @if($filterBy == 'hours')
+                            <div class="col-span-2 xl:col-span-1 border-2 @if($filterBy == 'hours')
                                     border-green-base bg-green-light
                                 @else
                                     border-gray-200
@@ -360,7 +360,7 @@
                                     </span>
                                 </div>
                             </div>
-                            <div class="col-span-1 border-2 @if($filterBy == 'sets')
+                            <div class="col-span-2 xl:col-span-1 border-2 @if($filterBy == 'sets')
                                     border-green-base bg-green-light
                                 @else
                                     border-gray-200
@@ -385,7 +385,7 @@
                                     </span>
                                 </div>
                             </div>
-                            <div class="col-span-1 border-2 @if($filterBy == 'sits')
+                            <div class="col-span-3 xl:col-span-2 border-2 @if($filterBy == 'sits')
                                     border-green-base bg-green-light
                                 @else
                                     border-gray-200
@@ -394,23 +394,46 @@
                                 rounded-lg p-3"
                                 wire:click="setFilterBy('sits')">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Sits</div>
-                                <div class="text-xl font-bold text-gray-900">{{$numbersTracked->sum('sits')}}</div>
-                                <div class="flex text-xs font-semibold text-green-base">
-                                    @if($numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits') >= 0)
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
-                                    @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
-                                    @endif
-                                    <span class="@if($numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits') >= 0)
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">Set</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('set_sits')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($numbersTracked->sum('set_sits') - $numbersTrackedLast->sum('set_sits') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($numbersTracked->sum('set_sits') - $numbersTrackedLast->sum('set_sits') >= 0)
                                                     text-green-base
                                                 @else
                                                     text-red-600
                                                 @endif">
-                                        {{$numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits')}}
-                                    </span>
+                                            {{$numbersTracked->sum('set_sits') - $numbersTrackedLast->sum('set_sits')}}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">SG</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('sits')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits') >= 0)
+                                                    text-green-base
+                                                @else
+                                                    text-red-600
+                                                @endif">
+                                            {{$numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits')}}
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="col-span-1 border-2 @if($filterBy == 'set_closes')
+                            {{-- <div class="col-span-1 border-2 @if($filterBy == 'set_closes')
                                     border-green-base bg-green-light
                                 @else
                                     border-gray-200
@@ -434,8 +457,8 @@
                                         {{$numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes')}}
                                     </span>
                                 </div>
-                            </div>
-                            <div class="col-span-1 border-2 @if($filterBy == 'closes')
+                            </div> --}}
+                            <div class="col-span-3 xl:col-span-2 border-2 @if($filterBy == 'closes')
                                     border-green-base bg-green-light
                                 @else
                                     border-gray-200
@@ -444,20 +467,43 @@
                                 rounded-lg p-3"
                                 wire:click="setFilterBy('closes')">
                                 <div class="text-xs font-semibold text-gray-900 uppercase">Closes</div>
-                                <div class="text-xl font-bold text-gray-900">{{$numbersTracked->sum('closes')}}</div>
-                                <div class="flex text-xs font-semibold text-green-base">
-                                    @if($numbersTracked->sum('doors') - $numbersTrackedLast->sum('doors') >= 0)
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
-                                    @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
-                                    @endif
-                                    <span class="@if($numbersTracked->sum('doors') - $numbersTrackedLast->sum('doors') >= 0)
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">Set</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('set_closes')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes') >= 0)
                                                     text-green-base
                                                 @else
                                                     text-red-600
                                                 @endif">
-                                        {{$numbersTracked->sum('closes') - $numbersTrackedLast->sum('closes')}}
-                                    </span>
+                                            {{$numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes')}}
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="grid grid-cols-4 gap-1">
+                                    <div class="text-sm self-center col-span-1">SG</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('sits')}}</div>
+                                    <div class="flex place-self-end col-span-1 items-center">
+                                        @if($numbersTracked->sum('closes') - $numbersTrackedLast->sum('closes') >= 0)
+                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        @else
+                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        @endif
+                                        <span class="
+                                                @if($numbersTracked->sum('closes') - $numbersTrackedLast->sum('closes') >= 0)
+                                                    text-green-base
+                                                @else
+                                                    text-red-600
+                                                @endif">
+                                            {{$numbersTracked->sum('closes') - $numbersTrackedLast->sum('closes')}}
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
+++ b/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
@@ -322,9 +322,9 @@
                                 <div class="text-xl font-bold">{{$numbersTracked->sum('doors')}}</div>
                                 <div class="flex text-xs font-semibold text-green-base">
                                     @if($numbersTracked->sum('doors') - $numbersTrackedLast->sum('doors') >= 0)
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                     @endif
                                     <span class="@if($numbersTracked->sum('doors') - $numbersTrackedLast->sum('doors') >= 0)
                                                     text-green-base
@@ -347,9 +347,9 @@
                                 <div class="text-xl font-bold text-gray-900">{{$numbersTracked->sum('hours')}}</div>
                                 <div class="flex text-xs font-semibold text-green-base">
                                     @if($numbersTracked->sum('hours') - $numbersTrackedLast->sum('hours') >= 0)
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                     @endif
                                     <span class="@if($numbersTracked->sum('hours') - $numbersTrackedLast->sum('hours') >= 0)
                                                     text-green-base
@@ -372,9 +372,9 @@
                                 <div class="text-xl font-bold text-gray-900">{{$numbersTracked->sum('sets')}}</div>
                                 <div class="flex text-xs font-semibold text-green-base">
                                     @if($numbersTracked->sum('sets') - $numbersTrackedLast->sum('sets') >= 0)
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                     @endif
                                     <span class="@if($numbersTracked->sum('sets') - $numbersTrackedLast->sum('sets') >= 0)
                                                     text-green-base
@@ -399,9 +399,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('set_sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($numbersTracked->sum('set_sits') - $numbersTrackedLast->sum('set_sits') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($numbersTracked->sum('set_sits') - $numbersTrackedLast->sum('set_sits') >= 0)
@@ -418,9 +418,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($numbersTracked->sum('sits') - $numbersTrackedLast->sum('sits') >= 0)
@@ -445,9 +445,9 @@
                                 <div class="text-xl font-bold text-gray-900">{{$numbersTracked->sum('set_closes')}}</div>
                                 <div class="flex text-xs font-semibold text-green-base">
                                     @if($numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes') >= 0)
-                                        <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                        <x-svg.arrow-up class="text-green-base"/>
                                     @else
-                                        <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                        <x-svg.arrow-down class="text-red-600"/>
                                     @endif
                                     <span class="@if($numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes') >= 0)
                                                     text-green-base
@@ -472,9 +472,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('set_closes')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($numbersTracked->sum('set_closes') - $numbersTrackedLast->sum('set_closes') >= 0)
@@ -491,9 +491,9 @@
                                     <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('sits')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($numbersTracked->sum('closes') - $numbersTrackedLast->sum('closes') >= 0)
-                                            <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                            <x-svg.arrow-up class="text-green-base"/>
                                         @else
-                                            <x-svg.arrow-down class="text-red-600"></x-svg.arrow-down>
+                                            <x-svg.arrow-down class="text-red-600"/>
                                         @endif
                                         <span class="
                                                 @if($numbersTracked->sum('closes') - $numbersTrackedLast->sum('closes') >= 0)
@@ -522,9 +522,9 @@
                                     text-green-base
                                 @endif">
                                 @if($graficValueLast > $graficValue)
-                                    <x-svg.arrow-down class="text-red-600"></x-svg.arrow-up>
+                                    <x-svg.arrow-down class="text-red-600"/>
                                 @else
-                                    <x-svg.arrow-up class="text-green-base"></x-svg.arrow-up>
+                                    <x-svg.arrow-up class="text-green-base"/>
                                 @endif
                                 <span>
                                     {{$graficValue - $graficValueLast}}

--- a/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
+++ b/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
@@ -544,6 +544,9 @@
                                                         <x-table.th by="sets">
                                                             @lang('Sets')
                                                         </x-table.th>
+                                                        <x-table.th by="set_sits">
+                                                            @lang('Set Sits')
+                                                        </x-table.th>
                                                         <x-table.th by="sits">
                                                             @lang('Sits')
                                                         </x-table.th>
@@ -565,6 +568,7 @@
                                                             <x-table.td>{{ $row['doors'] ?? 0 }}</x-table.td>
                                                             <x-table.td>{{ $row['hours'] ?? 0 }}</x-table.td>
                                                             <x-table.td>{{ $row['sets'] ?? 0 }}</x-table.td>
+                                                            <x-table.td>{{ $row['set_sits'] ?? 0 }}</x-table.td>
                                                             <x-table.td>{{ $row['sits'] ?? 0 }}</x-table.td>
                                                             <x-table.td>{{ $row['set_closes'] ?? 0 }}</x-table.td>
                                                             <x-table.td>{{ $row['closes'] ?? 0 }}</x-table.td>

--- a/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
+++ b/resources/views/livewire/number-tracker/number-tracker-detail.blade.php
@@ -488,7 +488,7 @@
                                 </div>
                                 <div class="grid grid-cols-4 gap-1">
                                     <div class="text-sm self-center col-span-1">SG</div>
-                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('sits')}}</div>
+                                    <div class="text-md font-bold text-gray-900 col-span-2">{{$numbersTracked->sum('closes')}}</div>
                                     <div class="flex place-self-end col-span-1 items-center">
                                         @if($numbersTracked->sum('closes') - $numbersTrackedLast->sum('closes') >= 0)
                                             <x-svg.arrow-up class="text-green-base"/>


### PR DESCRIPTION
## Goal

Add new input set sits on update numbers

## Changeset

- Add new input to insert set sits
- change overview cards: remove set closes card and add SG on sits and closes cards

## Tests

- [ ] Go to one energy project
- [ ] open number tracker page 
- [ ] see if sits and closes card are showed correctly
  obs: in cards sits and closes the labels means
     - Sg is the closes ou sits
     - set is the set closes or set sits

## Discussion


## Review


For the submitter, initial self-review:

- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency between the changeset and the goal stated above
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Complexity - is the proposed change introducing any unjustified complexity? 
- [ ] Thoroughness of added tests and any missing edge cases
